### PR TITLE
Pass inventory_dir variable to ansible

### DIFF
--- a/deploy-site-app.sh
+++ b/deploy-site-app.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com"
-ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com"
+ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com inventory_dir=`pwd`/environment"
 
 echo ""
 echo "Next steps:"


### PR DESCRIPTION
Using ansible 2.5 the following error is thrown:

    ERROR! Error when evaluating variable in include name: {{ inventory_dir }}/handlers/common.yml.

    When using static includes, ensure that any variables used in their names are defined in vars/vars_files
    or extra-vars passed in from the command line. Static includes cannot use variables from inventory
    sources like group or host vars.

By passing the directory as a command-line argument we ensure the
inventory_dir variable is always available.