### PR TITLE
Enable 'ioapic' for the Virtualbox provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,6 +75,7 @@ Vagrant.configure("2") do |config|
     # VirtualBox specific configuration
     app.vm.provider "virtualbox" do |v|
       # Use the default (vboxsf)
+      v.customize ["modifyvm", :id, "--ioapic", "on"]
       v.customize ["modifyvm", :id, "--memory", "2048"]
       v.customize ["modifyvm", :id, "--cpus", "2"]
 


### PR DESCRIPTION
As Virtualbox states in its man pages: 

> Enabling the I/O APIC is required for 64-bit guest operating systems. [1]

And enabling this option significantly sped up the performance of my VM.

Credits to @jorissteyn for finding this solution [2].

[1] https://www.virtualbox.org/manual/ch03.html#settings-motherboard
[2] https://www.pivotaltracker.com/story/show/155814827/comments/188020523