### PR TITLE
Add the 'no_root_squash' nfs option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure("2") do |config|
       if src_path != nil then
         app.vm.synced_folder "./src/", "/src",
           nfs: true,
-          linux__nfs_options: ['rw','no_subtree_check','all_squash','async']
+          linux__nfs_options: ['rw','no_subtree_check','all_squash','no_root_squash','async']
           #:mount_options => ['nolock,vers=3,udp,noatime,actimeo=1']
       end
 


### PR DESCRIPTION
This is required to perform the setfacl operations on an Ubuntu host.
On Arch this was not required (same NFS versions). It remains a mystery
why we need this on Ubuntu.

Usage of the 'no_root_squash' option is discouraged but in this isolated
dev environment it should not pose to much risk.