### PR TITLE
Add two demo GSSP's for integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ This script runs the Ansible playbook "site.yml" on the app server (app.stepup.e
 Because this is a development server:
 - MariaDB galera cluster is bootsrapped and configured as one node and a script is installed to bootstrap the node after boot. 
 
+## 5. Use the test GSSP's
+
+You could add the hosts below to your `/etc/hosts` file to use the test GSSP's
+```
+192.168.66.3 demo-gssp.stepup.example.com demo-gssp-2.stepup.example.com
+```
+
 # Troubleshooting
 
 ## I'm getting an error while creating / setting up the VM's 

--- a/clone-repos.sh
+++ b/clone-repos.sh
@@ -66,4 +66,18 @@ else
     echo "Directory ./deploy exists. Skipping git clone into that directory."
 fi
 
+
+
+if [ ! -e "./src/stepup-demo-gssp" ]; then
+  git clone https://github.com/OpenConext/Stepup-gssp-example.git ./src/stepup-demo-gssp
+else
+  echo "Directory ./src/Stepup-gssp-example exists. Skipping git clone into that directory."
+fi
+
+if [ ! -e "./src/stepup-demo-gssp-2" ]; then
+  git clone https://github.com/OpenConext/Stepup-gssp-example.git ./src/stepup-demo-gssp-2
+else
+  echo "Directory ./src/Stepup-gssp-example-2 exists. Skipping git clone into that directory."
+fi
+
 echo "OK."

--- a/deploy-develop.sh
+++ b/deploy-develop.sh
@@ -13,6 +13,8 @@ COMPONENTS=(
 "Stepup-RA"
 "Stepup-tiqr"
 "oath-service-php"
+"stepup-demo-gssp"
+"stepup-demo-gssp-2"
 )
 
 for comp in "${COMPONENTS[@]}"; do

--- a/deploy-site-app.sh
+++ b/deploy-site-app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com" $@
+echo ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com inventory_dir=`pwd`/environment" $@
 ansible-playbook deploy/site.yml -i environment/inventory -l app* -e "galera_bootstrap_node=app.stepup.example.com inventory_dir=`pwd`/environment" $@
 
 echo ""


### PR DESCRIPTION
This is done only for development so the integration could be tested.
The production GSSP's need to be internet facing to do validation, this
prevents automatic testing. So in order to have some decent integration
tests this is needed.